### PR TITLE
ensure correct input order. fix #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 compile_commands.json
+.vimsession.vim
 .clangd


### PR DESCRIPTION
simplified code. instead of using one struct for each scroll layer, use unified variables for each kind of layer.
repeat-8 also applies to repeat-last-key now.